### PR TITLE
bug fix on line 38

### DIFF
--- a/tweetie.js
+++ b/tweetie.js
@@ -35,7 +35,7 @@
          */
         var linking = function (tweet) {
             var twit = tweet.replace(/(https?:\/\/([-\w\.]+)+(:\d+)?(\/([\w\/_\.]*(\?\S+)?)?)?)/ig,'<a href="$1" target="_blank" title="Visit this link">$1</a>')
-                 .replace(/#([a-zA-Z0-9_]+)/g,'<a href="http://twitter.com/search?q=%23$1&amp;src=hash" target="_blank" title="Search for #$1">#$1</a>')
+                 .replace(/#([a-zA-Z0-9_]+)/g,'<a href="http://twitter.com/search?q=$1&amp;src=hash" target="_blank" title="Search for #$1">#$1</a>')
                  .replace(/@([a-zA-Z0-9_]+)/g,'<a href="http://twitter.com/$1" target="_blank" title="$1 on Twitter">@$1</a>');
 
             return twit;


### PR DESCRIPTION
all hash(#) links were getting 23 added at the front.  i took out %23 from line 38.  checked out the results from my site www.dailycnt.com and the #links work perfectly fine now.  
